### PR TITLE
fix: parsing of RFC 3339 dates without explicit timezone

### DIFF
--- a/lua/crates/time.lua
+++ b/lua/crates/time.lua
@@ -17,7 +17,7 @@ function DateTime.parse_rfc_3339(str)
     -- lua regex suports no {n} occurences
     local pat = "^([0-9][0-9][0-9][0-9])%-([0-9][0-9])%-([0-9][0-9])" -- date
         .. "T([0-9][0-9]):([0-9][0-9]):([0-9][0-9])%.[0-9]+"          -- time
-        .. "([%+%-])([0-9][0-9]):([0-9][0-9])$"                       -- offset
+        .. "([%+%-Z])([0-9]?[0-9]?):?([0-9]?[0-9]?)$"                 -- offset
 
     local year, month, day, hour, minute, second, offset, offset_hour, offset_minute = str:match(pat)
     if year then
@@ -29,6 +29,9 @@ function DateTime.parse_rfc_3339(str)
         elseif offset == "-" then
             h = tonumber(hour) - tonumber(offset_hour)
             m = tonumber(minute) - tonumber(offset_minute)
+        elseif offset == 'Z' then
+            h = tonumber(hour)
+            m = tonumber(minute)
         end
         return DateTime.new(os.time({
             ---@diagnostic disable-next-line: assign-type-mismatch


### PR DESCRIPTION
Relaxes the requirement of having an explicit timezone (`+HH:MM`) in the date string, and adds support for `Z` suffixes representing UTC.

<!-- Please use conventional commit messages for PR titles: https://www.conventionalcommits.org/en/v1.0.0 -->
